### PR TITLE
Add build commands for backend Dockerfile and frontend Netlify configuration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,21 @@
-# Backend Dockerfile for Citizen Complaints System
-FROM node:18-alpine
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install --production
+RUN npm install
 
 COPY . .
 
 RUN npm run build
+
+FROM node:18-alpine AS prod
+
+WORKDIR /app
+
+COPY --from=builder /app .
+
+RUN npm prune --production
 
 EXPOSE 4000
 


### PR DESCRIPTION
Introduce build commands to streamline the deployment process for both the backend and frontend applications.